### PR TITLE
Fix neurospace dashboard runtime errors

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
-export const dynamic = 'force-dynamic';
+'use client';
+
 import { 
   DocumentTextIcon, 
   ChatBubbleLeftRightIcon, 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,17 @@ import {
 import clsx from 'classnames';
 import { componentClasses, designTokens, getCardClass, getButtonClass } from '@/lib/design-system';
 
+// Safe hook to handle cases when Clerk is not configured
+function useSafeUser() {
+  try {
+    return useUser();
+  } catch (error) {
+    // If Clerk is not properly configured, return null user
+    console.warn('Clerk not configured, using fallback user state');
+    return { user: null, isLoaded: true, isSignedIn: false };
+  }
+}
+
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: HomeIcon, description: 'Overview & analytics' },
   { name: 'Documents', href: '/dashboard/documents', icon: DocumentTextIcon, description: 'Manage your files' },
@@ -38,7 +49,7 @@ export default function Sidebar() {
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
-  const { user } = useUser();
+  const { user } = useSafeUser();
 
   // Update document body class for layout adjustments
   useEffect(() => {


### PR DESCRIPTION
Fix dashboard runtime errors by adding the 'use client' directive and a safe hook for Clerk authentication.

The initial error report pointed to JSX syntax and duplicate exports, which were not found. The actual issues causing the "Element type is invalid" error were identified as: 1) `useUser` being called outside of a `ClerkProvider` context (due to missing environment variables), and 2) dynamic component rendering within the dashboard page requiring the `'use client'` directive for proper hydration.

---
<a href="https://cursor.com/background-agent?bcId=bc-dcff9f90-ebd6-4d7c-91f8-4f8f91466b64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dcff9f90-ebd6-4d7c-91f8-4f8f91466b64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

